### PR TITLE
Style improvements

### DIFF
--- a/ckanext/sprout/assets/css/custom.css
+++ b/ckanext/sprout/assets/css/custom.css
@@ -314,13 +314,18 @@ a:hover {
   }
 }
 .media-item {
-  height: 340px;
+  height: 350px;
 }
 .media-description {
   text-align: justify;
 }
 .media-heading {
   word-break: break-all !important;
+}
+.image-fit {
+  display: block;
+  max-width: 100%;
+  height: 30%;
 }
 @font-face {
   font-family: "Open Sans";

--- a/ckanext/sprout/assets/css/custom.css
+++ b/ckanext/sprout/assets/css/custom.css
@@ -313,6 +313,15 @@ a:hover {
     font-size: 14px;
   }
 }
+.media-item {
+  height: 340px;
+}
+.media-description {
+  text-align: justify;
+}
+.media-heading {
+  word-break: break-all !important;
+}
 @font-face {
   font-family: "Open Sans";
   src: url('/base/fonts/OpenSans-Regular.woff2') format('woff2');

--- a/ckanext/sprout/assets/less/_groups.less
+++ b/ckanext/sprout/assets/less/_groups.less
@@ -1,5 +1,5 @@
 .media-item {
-    height: 340px;
+    height: 350px;
 }
 
 .media-description {
@@ -8,4 +8,10 @@
 
 .media-heading {
     word-break: break-all !important;
+}
+
+.image-fit {
+    display: block;
+    max-width: 100%;
+    height: 30%;
 }

--- a/ckanext/sprout/assets/less/_groups.less
+++ b/ckanext/sprout/assets/less/_groups.less
@@ -1,0 +1,11 @@
+.media-item {
+    height: 340px;
+}
+
+.media-description {
+    text-align: justify;
+}
+
+.media-heading {
+    word-break: break-all !important;
+}

--- a/ckanext/sprout/assets/less/custom.less
+++ b/ckanext/sprout/assets/less/custom.less
@@ -7,4 +7,5 @@
 @import "_nav.less";
 @import "_buttons.less";
 @import "_toolbar.less";
+@import "_groups.less";
 @import "_fonts.less";

--- a/ckanext/sprout/templates/footer.html
+++ b/ckanext/sprout/templates/footer.html
@@ -9,13 +9,6 @@
                 <li><a href="{{ h.url_for(controller='home', action='about') }}">{{ _('About {0}').format(g.site_title) }}</a></li>
               {% endblock %}
             </ul>
-            <ul class="list-unstyled">
-              {% block footer_links_ckan %}
-                {% set api_url = 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version) %}
-                <li><a href="{{ api_url }}">{{ _('CKAN API') }}</a></li>
-                <li><a href="http://www.ckan.org/">{{ _('CKAN Association') }}</a></li>
-              {% endblock %}
-            </ul>
           {% endblock %}
         </div>
         <div class="col-md-4 attribution">

--- a/ckanext/sprout/templates/group/snippets/group_item.html
+++ b/ckanext/sprout/templates/group/snippets/group_item.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+{% set type = group.type or 'group' %}
+{% set url = h.url_for(type ~ '.read', id=group.name) %}
+
+{{ super() }}
+{% block title %}
+
+<h2 class="media-heading">{{ group.display_name|truncate(30, True, '...') }}</h2>
+{% endblock %}
+{% block description %}
+{% if group.description %}
+<p class="media-description">{{ h.markdown_extract(group.description|truncate(100, True, '...'), extract_length=80) }}
+</p>
+{% endif %}
+
+{% endblock %}

--- a/ckanext/sprout/templates/group/snippets/group_item.html
+++ b/ckanext/sprout/templates/group/snippets/group_item.html
@@ -3,8 +3,12 @@
 {% set url = h.url_for(type ~ '.read', id=group.name) %}
 
 {{ super() }}
-{% block title %}
 
+{% block image %}
+<img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" height="150px"
+    alt="{{ group.name }}" class="media-image image-fit">
+{% endblock %}
+{% block title %}
 <h2 class="media-heading">{{ group.display_name|truncate(30, True, '...') }}</h2>
 {% endblock %}
 {% block description %}

--- a/ckanext/sprout/templates/organization/snippets/organization_item.html
+++ b/ckanext/sprout/templates/organization/snippets/organization_item.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% set url = h.url_for(organization.type ~ '.read', id=organization.name) %}
+{{ super() }}
+
+{% block title %}
+<h2 class="media-heading">{{ organization.display_name|truncate(30, True, '...') }}</h2>
+{% endblock %}

--- a/ckanext/sprout/templates/organization/snippets/organization_item.html
+++ b/ckanext/sprout/templates/organization/snippets/organization_item.html
@@ -3,6 +3,10 @@
 {% set url = h.url_for(organization.type ~ '.read', id=organization.name) %}
 {{ super() }}
 
+{% block image %}
+<img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}"
+    alt="{{ organization.name }}" class="image-fit media-image">
+{% endblock %}
 {% block title %}
 <h2 class="media-heading">{{ organization.display_name|truncate(30, True, '...') }}</h2>
 {% endblock %}

--- a/ckanext/sprout/templates/snippets/group_item.html
+++ b/ckanext/sprout/templates/snippets/group_item.html
@@ -17,7 +17,7 @@
       {% endblock %}
       {% block group_item_header_title %}
       <h3 class="media-heading mt-5"><a href="{{ h.url_for(controller='group', action='read', id=group.name) }}">{{
-          group.title or group.name }}</a></h3>
+          group.title|truncate(40, True, '...') or group.name|truncate(30, True, '...') }}</a></h3>
       {% endblock %}
     </div>
   </header>


### PR DESCRIPTION
Remove Ckan API and CKAN associations references on footer (requested my MercyCorps)

Style groups and organizations pages. 
Related issue:
https://gitlab.com/keitaro/mercy-corps-ckan-portal/-/issues/47