### PR TITLE
Remove wordbreak on groups and stories headings

### DIFF
--- a/ckanext/sprout/assets/css/custom.css
+++ b/ckanext/sprout/assets/css/custom.css
@@ -152,7 +152,6 @@ a:hover {
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  word-break: break-all !important;
   padding-top: 10px;
   padding-bottom: 10px;
   overflow: hidden;
@@ -408,9 +407,6 @@ a:hover {
 }
 .media-description {
   text-align: center;
-}
-.media-heading {
-  word-break: break-all !important;
 }
 .image-fit {
   display: block;

--- a/ckanext/sprout/assets/css/custom.css
+++ b/ckanext/sprout/assets/css/custom.css
@@ -219,9 +219,6 @@ a:hover {
 .table-bordered {
   word-break: break-all;
 }
-.page-heading {
-  word-break: break-all !important;
-}
 @media (max-width: 767px) {
   .centered {
     display: -webkit-box;

--- a/ckanext/sprout/assets/less/_groups.less
+++ b/ckanext/sprout/assets/less/_groups.less
@@ -6,10 +6,6 @@
     text-align: center;
 }
 
-.media-heading {
-    word-break: break-all !important;
-}
-
 .image-fit {
     display: block;
     max-width: 100%;

--- a/ckanext/sprout/assets/less/_index.less
+++ b/ckanext/sprout/assets/less/_index.less
@@ -169,7 +169,6 @@ a:hover {
   height: 66px;
   align-items: center;
   justify-content: center;
-  word-break: break-all !important;
   padding-top: 10px;
   padding-bottom: 10px;
   overflow: hidden;

--- a/ckanext/sprout/assets/less/_index.less
+++ b/ckanext/sprout/assets/less/_index.less
@@ -235,10 +235,6 @@ a:hover {
   word-break: break-all;
 }
 
-.page-heading {
-  word-break: break-all !important;
-}
-
 @media (max-width: 767px) {
   .centered {
       display: flex;


### PR DESCRIPTION
Updated: titles on groups and stories should not be cropped in the middle of the word.