### PR TITLE
Optimize font load

### DIFF
--- a/ckanext/sprout/assets/css/custom.css
+++ b/ckanext/sprout/assets/css/custom.css
@@ -416,46 +416,54 @@ a:hover {
   src: url('/base/fonts/OpenSans-Regular.woff2') format('woff2');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Open Sans";
   src: url('/base/fonts/OpenSans-Bold.woff2') format('woff2');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Open Sans";
   src: url('/base/fonts/OpenSans-Italic.woff2') format('woff2');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Open Sans";
   src: url('/base/fonts/OpenSans-BoldItalic.woff2') format('woff2');
   font-weight: bold;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Open Sans";
   src: url('/base/fonts/OpenSans-Light.woff2') format('woff2');
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Open Sans";
   src: url('/base/fonts/OpenSans-LightItalic.woff2') format('woff2');
   font-weight: 300;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Open Sans";
   src: url('/base/fonts/OpenSans-Medium.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Open Sans";
   src: url('/base/fonts/OpenSans-MediumItalic.woff2') format('woff2');
   font-weight: 500;
   font-style: italic;
+  font-display: swap;
 }

--- a/ckanext/sprout/assets/less/_fonts.less
+++ b/ckanext/sprout/assets/less/_fonts.less
@@ -3,6 +3,7 @@
     src: url('/base/fonts/OpenSans-Regular.woff2') format('woff2');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -10,6 +11,7 @@
     src: url('/base/fonts/OpenSans-Bold.woff2') format('woff2');
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -17,6 +19,7 @@
     src: url('/base/fonts/OpenSans-Italic.woff2') format('woff2');
     font-weight: normal;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
@@ -24,6 +27,7 @@
     src: url('/base/fonts/OpenSans-BoldItalic.woff2') format('woff2');
     font-weight: bold;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
@@ -31,6 +35,7 @@
     src: url('/base/fonts/OpenSans-Light.woff2') format('woff2');
     font-weight: 300;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -38,6 +43,7 @@
     src: url('/base/fonts/OpenSans-LightItalic.woff2') format('woff2');
     font-weight: 300;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
@@ -45,6 +51,7 @@
     src: url('/base/fonts/OpenSans-Medium.woff2') format('woff2');
     font-weight: 500;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -52,4 +59,5 @@
     src: url('/base/fonts/OpenSans-MediumItalic.woff2') format('woff2');
     font-weight: 500;
     font-style: italic;
+    font-display: swap;
 }


### PR DESCRIPTION
Optimizing fonts. Text remains visible during webfont load

Related issue:
https://gitlab.com/keitaro/mc-sprout-platform-support/support-task-board/-/issues/2